### PR TITLE
Move _ctype to PROGMEM, update accessors

### DIFF
--- a/newlib/libc/ctype/ctype_.c
+++ b/newlib/libc/ctype/ctype_.c
@@ -36,6 +36,7 @@ static char sccsid[] = "@(#)ctype_.c	5.6 (Berkeley) 6/1/90";
 #endif /* LIBC_SCCS and not lint */
 
 #include <ctype.h>
+#include "../machine/xtensa/pgmspace.h"
 
 #define _CTYPE_DATA_0_127 \
 	_C,	_C,	_C,	_C,	_C,	_C,	_C,	_C, \
@@ -137,7 +138,7 @@ _CONST char _ctype_[1 + 256] = {
 
 #else	/* !defined(ALLOW_NEGATIVE_CTYPE_INDEX) */
 
-_CONST char _ctype_[1 + 256] = {
+_CONST char _ctype_[1 + 256] PROGMEM = {
 	0,
 	_CTYPE_DATA_0_127,
 	_CTYPE_DATA_128_255

--- a/newlib/libc/ctype/isalnum.c
+++ b/newlib/libc/ctype/isalnum.c
@@ -35,12 +35,13 @@ No OS subroutines are required.
 
 #include <_ansi.h>
 #include <ctype.h>
+#include "../machine/xtensa/pgmspace.h"
 
 #undef isalnum
 
 int
 _DEFUN(isalnum,(c),int c)
 {
-	return(__ctype_ptr__[c+1] & (_U|_L|_N));
+	return(pgm_read_byte(&__ctype_ptr__[c+1]) & (_U|_L|_N));
 }
 

--- a/newlib/libc/ctype/isalpha.c
+++ b/newlib/libc/ctype/isalpha.c
@@ -34,11 +34,12 @@ No supporting OS subroutines are required.
 
 #include <_ansi.h>
 #include <ctype.h>
+#include "../machine/xtensa/pgmspace.h"
 
 #undef isalpha
 int
 _DEFUN(isalpha,(c),int c)
 {
-	return(__ctype_ptr__[c+1] & (_U|_L));
+	return(pgm_read_byte(&__ctype_ptr__[c+1]) & (_U|_L));
 }
 

--- a/newlib/libc/ctype/isblank.c
+++ b/newlib/libc/ctype/isblank.c
@@ -31,6 +31,7 @@ No supporting OS subroutines are required.
 
 #include <_ansi.h>
 #include <ctype.h>
+#include "../machine/xtensa/pgmspace.h"
 
 
 
@@ -38,5 +39,5 @@ No supporting OS subroutines are required.
 int
 _DEFUN(isblank,(c),int c)
 {
-	return ((__ctype_ptr__[c+1] & _B) || (c == '\t'));
+	return ((pgm_read_byte(&__ctype_ptr__[c+1]) & _B) || (c == '\t'));
 }

--- a/newlib/libc/ctype/iscntrl.c
+++ b/newlib/libc/ctype/iscntrl.c
@@ -35,6 +35,7 @@ No supporting OS subroutines are required.
 
 #include <_ansi.h>
 #include <ctype.h>
+#include "../machine/xtensa/pgmspace.h"
 
 
 
@@ -42,7 +43,7 @@ No supporting OS subroutines are required.
 int
 _DEFUN(iscntrl,(c),int c)
 {
-	return(__ctype_ptr__[c+1] & _C);
+	return(pgm_read_byte(&__ctype_ptr__[c+1]) & _C);
 }
 
 

--- a/newlib/libc/ctype/isdigit.c
+++ b/newlib/libc/ctype/isdigit.c
@@ -33,11 +33,12 @@ No supporting OS subroutines are required.
 
 #include <_ansi.h>
 #include <ctype.h>
+#include "../machine/xtensa/pgmspace.h"
 
 
 #undef isdigit
 int
 _DEFUN(isdigit,(c),int c)
 {
-	return(__ctype_ptr__[c+1] & _N);
+	return(pgm_red_byte(&__ctype_ptr__[c+1]) & _N);
 }

--- a/newlib/libc/ctype/islower.c
+++ b/newlib/libc/ctype/islower.c
@@ -34,11 +34,12 @@ No supporting OS subroutines are required.
 */
 #include <_ansi.h>
 #include <ctype.h>
+#include "../machine/xtensa/pgmspace.h"
 
 #undef islower
 int
 _DEFUN(islower,(c),int c)
 {
-	return ((__ctype_ptr__[c+1] & (_U|_L)) == _L);
+	return ((pgm_read_byte(&__ctype_ptr__[c+1]) & (_U|_L)) == _L);
 }
 

--- a/newlib/libc/ctype/isprint.c
+++ b/newlib/libc/ctype/isprint.c
@@ -43,12 +43,13 @@ No supporting OS subroutines are required.
 
 #include <_ansi.h>
 #include <ctype.h>
+#include "../machine/xtensa/pgmspace.h"
 
 #undef isgraph
 int
 _DEFUN(isgraph,(c),int c)
 {
-	return(__ctype_ptr__[c+1] & (_P|_U|_L|_N));
+	return(pgm_read_byte(&__ctype_ptr__[c+1]) & (_P|_U|_L|_N));
 }
 
 
@@ -56,6 +57,6 @@ _DEFUN(isgraph,(c),int c)
 int
 _DEFUN(isprint,(c),int c)
 {
-	return(__ctype_ptr__[c+1] & (_P|_U|_L|_N|_B));
+	return(pgm_read_byte(&__ctype_ptr__[c+1]) & (_P|_U|_L|_N|_B));
 }
 

--- a/newlib/libc/ctype/ispunct.c
+++ b/newlib/libc/ctype/ispunct.c
@@ -35,12 +35,13 @@ No supporting OS subroutines are required.
 
 #include <_ansi.h>
 #include <ctype.h>
+#include "../machine/xtensa/pgmspace.h"
 
 
 #undef ispunct
 int
 _DEFUN(ispunct,(c),int c)
 {
-	return(__ctype_ptr__[c+1] & _P);
+	return(pgm_read_byte(&__ctype_ptr__[c+1]) & _P);
 }
 

--- a/newlib/libc/ctype/isspace.c
+++ b/newlib/libc/ctype/isspace.c
@@ -33,12 +33,13 @@ No supporting OS subroutines are required.
 */
 #include <_ansi.h>
 #include <ctype.h>
+#include "../machine/xtensa/pgmspace.h"
 
 
 #undef isspace
 int
 _DEFUN(isspace,(c),int c)
 {
-	return(__ctype_ptr__[c+1] & _S);
+	return(pgm_read_byte(&__ctype_ptr__[c+1]) & _S);
 }
 

--- a/newlib/libc/ctype/isupper.c
+++ b/newlib/libc/ctype/isupper.c
@@ -33,11 +33,12 @@ No supporting OS subroutines are required.
 */
 #include <_ansi.h>
 #include <ctype.h>
+#include "../machine/xtensa/pgmspace.h"
 
 #undef isupper
 int
 _DEFUN(isupper,(c),int c)
 {
-	return ((__ctype_ptr__[c+1] & (_U|_L)) == _U);
+	return ((pgm_read_byte(&__ctype_ptr__[c+1]) & (_U|_L)) == _U);
 }
 

--- a/newlib/libc/ctype/isxdigit.c
+++ b/newlib/libc/ctype/isxdigit.c
@@ -34,12 +34,12 @@ No supporting OS subroutines are required.
 */
 #include <_ansi.h>
 #include <ctype.h>
-
+#include "../machine/xtensa/pgmspace.h"
 
 #undef isxdigit
 int
 _DEFUN(isxdigit,(c),int c)
 {
-	return(__ctype_ptr__[c+1] & ((_X)|(_N)));
+	return(pgm_read_byte(&__ctype_ptr__[c+1]) & ((_X)|(_N)));
 }
 

--- a/newlib/libc/ctype/tolower.c
+++ b/newlib/libc/ctype/tolower.c
@@ -46,6 +46,7 @@ No supporting OS subroutines are required.
 
 #include <_ansi.h>
 #include <ctype.h>
+#include "../machine/xtensa/pgmspace.h"
 #if defined (_MB_EXTENDED_CHARSETS_ISO) || defined (_MB_EXTENDED_CHARSETS_WINDOWS)
 #include <limits.h>
 #include <stdio.h>

--- a/newlib/libc/ctype/toupper.c
+++ b/newlib/libc/ctype/toupper.c
@@ -45,6 +45,7 @@ No supporting OS subroutines are required.
 
 #include <_ansi.h>
 #include <ctype.h>
+#include "../machine/xtensa/pgmspace.h"
 #if defined (_MB_EXTENDED_CHARSETS_ISO) || defined (_MB_EXTENDED_CHARSETS_WINDOWS)
 #include <limits.h>
 #include <stdio.h>

--- a/newlib/libc/include/ctype.h
+++ b/newlib/libc/include/ctype.h
@@ -54,7 +54,7 @@ extern	__IMPORT char	*__ctype_ptr__;
    Meanwhile, the real index to __ctype_ptr__+1 must be cast to int,
    since isalpha(0x100000001LL) must equal isalpha(1), rather than being
    an out-of-bounds reference on a 64-bit machine.  */
-#define __ctype_lookup(__c) ((__ctype_ptr__+sizeof(""[__c]))[(int)(__c)])
+#define __ctype_lookup(__c) pgm_read_byte(&((__ctype_ptr__+sizeof(""[__c]))[(int)(__c)]))
 
 #define	isalpha(__c)	(__ctype_lookup(__c)&(_U|_L))
 #define	isupper(__c)	((__ctype_lookup(__c)&(_U|_L))==_U)

--- a/newlib/libc/machine/xtensa/pgmspace.h
+++ b/newlib/libc/machine/xtensa/pgmspace.h
@@ -1,0 +1,48 @@
+#ifndef ARDUINO
+
+#ifndef __PGMSPACE__
+#define __PGMSPACE__
+
+#include <stdint.h>
+
+#define PROGMEM __attribute__((section(".irom.text")))
+
+// flash memory must be read using 32 bit aligned addresses else a processor
+// exception will be triggered
+// order within the 32 bit values are
+// --------------
+// b3, b2, b1, b0
+//     w1,     w0
+
+#define pgm_read_with_offset(addr, res) \
+  asm("extui    %0, %1, 0, 2\n"     /* Extract offset within word (in bytes) */ \
+      "sub      %1, %1, %0\n"       /* Subtract offset from addr, yielding an aligned address */ \
+      "l32i.n   %1, %1, 0x0\n"      /* Load word from aligned address */ \
+      "slli     %0, %0, 3\n"        /* Mulitiply offset by 8, yielding an offset in bits */ \
+      "ssr      %0\n"               /* Prepare to shift by offset (in bits) */ \
+      "srl      %0, %1\n"           /* Shift right; now the requested byte is the first one */ \
+      :"=r"(res), "=r"(addr) \
+      :"1"(addr) \
+      :);
+
+static inline uint8_t pgm_read_byte_inlined(const void* addr) {
+  register uint32_t res;
+  pgm_read_with_offset(addr, res);
+  return (uint8_t) res;     /* This masks the lower byte from the returned word */
+}
+
+/* Although this says "word", it's actually 16 bit, i.e. half word on Xtensa */
+static inline uint16_t pgm_read_word_inlined(const void* addr) {
+  register uint32_t res;
+  pgm_read_with_offset(addr, res);
+  return (uint16_t) res;    /* This masks the lower half-word from the returned word */
+}
+
+// Make sure, that libraries checking existence of this macro are not failing
+#define pgm_read_byte(addr) pgm_read_byte_inlined(addr)
+#define pgm_read_word(addr) pgm_read_word_inlined(addr)
+
+#endif //__PGMSPACE__
+
+#endif // ARDUINO
+

--- a/newlib/libc/stdlib/strtol.c
+++ b/newlib/libc/stdlib/strtol.c
@@ -123,6 +123,7 @@ No supporting OS subroutines are required.
 #include <errno.h>
 #include <stdlib.h>
 #include <reent.h>
+#include "../machine/xtensa/pgmspace.h"
 
 /*
  * Convert a string to a long integer.


### PR DESCRIPTION
This patch is related to https://github.com/esp8266/Arduino/issues/3740 , increasing heap RAM on the ESP8266 by moving library constants into ROM.  

The _ctype array is included in most sketches automatically, taking up RAM.
Move the array to ROM, freeing the 257 bytes it takes, and modify all
accessor functions/macros to use pgm_read_byte to access it.