### PR TITLE
Move mprec_*tens arrays to PROGMEM

### DIFF
--- a/newlib/libc/machine/xtensa/pgmspace.h
+++ b/newlib/libc/machine/xtensa/pgmspace.h
@@ -1,0 +1,48 @@
+#ifndef ARDUINO
+
+#ifndef __PGMSPACE__
+#define __PGMSPACE__
+
+#include <stdint.h>
+
+#define PROGMEM __attribute__((section(".irom.text")))
+
+// flash memory must be read using 32 bit aligned addresses else a processor
+// exception will be triggered
+// order within the 32 bit values are
+// --------------
+// b3, b2, b1, b0
+//     w1,     w0
+
+#define pgm_read_with_offset(addr, res) \
+  asm("extui    %0, %1, 0, 2\n"     /* Extract offset within word (in bytes) */ \
+      "sub      %1, %1, %0\n"       /* Subtract offset from addr, yielding an aligned address */ \
+      "l32i.n   %1, %1, 0x0\n"      /* Load word from aligned address */ \
+      "slli     %0, %0, 3\n"        /* Mulitiply offset by 8, yielding an offset in bits */ \
+      "ssr      %0\n"               /* Prepare to shift by offset (in bits) */ \
+      "srl      %0, %1\n"           /* Shift right; now the requested byte is the first one */ \
+      :"=r"(res), "=r"(addr) \
+      :"1"(addr) \
+      :);
+
+static inline uint8_t pgm_read_byte_inlined(const void* addr) {
+  register uint32_t res;
+  pgm_read_with_offset(addr, res);
+  return (uint8_t) res;     /* This masks the lower byte from the returned word */
+}
+
+/* Although this says "word", it's actually 16 bit, i.e. half word on Xtensa */
+static inline uint16_t pgm_read_word_inlined(const void* addr) {
+  register uint32_t res;
+  pgm_read_with_offset(addr, res);
+  return (uint16_t) res;    /* This masks the lower half-word from the returned word */
+}
+
+// Make sure, that libraries checking existence of this macro are not failing
+#define pgm_read_byte(addr) pgm_read_byte_inlined(addr)
+#define pgm_read_word(addr) pgm_read_word_inlined(addr)
+
+#endif //__PGMSPACE__
+
+#endif // ARDUINO
+

--- a/newlib/libc/stdlib/mprec.c
+++ b/newlib/libc/stdlib/mprec.c
@@ -85,6 +85,7 @@
 #include <string.h>
 #include <reent.h>
 #include "mprec.h"
+#include "../machine/xtensa/pgmspace.h"
 
 /* This is defined in sys/reent.h as (sizeof (size_t) << 3) now, as in NetBSD.
    The old value of 15 was wrong and made newlib vulnerable against buffer
@@ -952,7 +953,7 @@ _DEFUN (ratio, (a, b), _Bigint * a _AND _Bigint * b)
 
 
 _CONST double
-  tens[] =
+  tens[] PROGMEM =
 {
   1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9,
   1e10, 1e11, 1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19,
@@ -961,16 +962,16 @@ _CONST double
 };
 
 #if !defined(_DOUBLE_IS_32BITS) && !defined(__v800)
-_CONST double bigtens[] =
+_CONST double bigtens[] PROGMEM =
 {1e16, 1e32, 1e64, 1e128, 1e256};
 
-_CONST double tinytens[] =
+_CONST double tinytens[] PROGMEM =
 {1e-16, 1e-32, 1e-64, 1e-128, 1e-256};
 #else
-_CONST double bigtens[] =
+_CONST double bigtens[] PROGMEM =
 {1e16, 1e32};
 
-_CONST double tinytens[] =
+_CONST double tinytens[] PROGMEM =
 {1e-16, 1e-32};
 #endif
 

--- a/newlib/libc/stdlib/strtod.c
+++ b/newlib/libc/stdlib/strtod.c
@@ -123,6 +123,7 @@ THIS SOFTWARE.
 /* #endif */
 
 #include "locale.h"
+#include "../machine/xtensa/pgmspace.h"
 
 #ifdef IEEE_Arith
 #ifndef NO_IEEE_Scale
@@ -130,7 +131,7 @@ THIS SOFTWARE.
 #undef tinytens
 /* The factor of 2^106 in tinytens[4] helps us avoid setting the underflow */
 /* flag unnecessarily.  It leads to a song and dance at the end of strtod. */
-static _CONST double tinytens[] = { 1e-16, 1e-32,
+static _CONST double tinytens[] PROGMEM = { 1e-16, 1e-32,
 #ifdef _DOUBLE_IS_32BITS
 				    0.0, 0.0, 0.0
 #else


### PR DESCRIPTION
This patch is related to https://github.com/esp8266/Arduino/issues/3740 , increasing heap RAM on the ESP8266 by moving library constants into ROM.  

There are several double[] arrays in mprec.c which can be moved to progmem
without any performance impact or code changes (doubles are 8-bytes, so
all accesses and alignments should be on 32-bit or even 64-bit boundaries).
strtod() also has the same (duplicated) tinytens array.
Saves about 280 bytes of RAM where these arrays appear.
