### PR TITLE
Move time function strings/consts to PMEM

### DIFF
--- a/newlib/libc/machine/xtensa/pgmspace.h
+++ b/newlib/libc/machine/xtensa/pgmspace.h
@@ -1,0 +1,48 @@
+#ifndef ARDUINO
+
+#ifndef __PGMSPACE__
+#define __PGMSPACE__
+
+#include <stdint.h>
+
+#define PROGMEM __attribute__((section(".irom.text")))
+
+// flash memory must be read using 32 bit aligned addresses else a processor
+// exception will be triggered
+// order within the 32 bit values are
+// --------------
+// b3, b2, b1, b0
+//     w1,     w0
+
+#define pgm_read_with_offset(addr, res) \
+  asm("extui    %0, %1, 0, 2\n"     /* Extract offset within word (in bytes) */ \
+      "sub      %1, %1, %0\n"       /* Subtract offset from addr, yielding an aligned address */ \
+      "l32i.n   %1, %1, 0x0\n"      /* Load word from aligned address */ \
+      "slli     %0, %0, 3\n"        /* Mulitiply offset by 8, yielding an offset in bits */ \
+      "ssr      %0\n"               /* Prepare to shift by offset (in bits) */ \
+      "srl      %0, %1\n"           /* Shift right; now the requested byte is the first one */ \
+      :"=r"(res), "=r"(addr) \
+      :"1"(addr) \
+      :);
+
+static inline uint8_t pgm_read_byte_inlined(const void* addr) {
+  register uint32_t res;
+  pgm_read_with_offset(addr, res);
+  return (uint8_t) res;     /* This masks the lower byte from the returned word */
+}
+
+/* Although this says "word", it's actually 16 bit, i.e. half word on Xtensa */
+static inline uint16_t pgm_read_word_inlined(const void* addr) {
+  register uint32_t res;
+  pgm_read_with_offset(addr, res);
+  return (uint16_t) res;    /* This masks the lower half-word from the returned word */
+}
+
+// Make sure, that libraries checking existence of this macro are not failing
+#define pgm_read_byte(addr) pgm_read_byte_inlined(addr)
+#define pgm_read_word(addr) pgm_read_word_inlined(addr)
+
+#endif //__PGMSPACE__
+
+#endif // ARDUINO
+

--- a/newlib/libc/time/asctime_r.c
+++ b/newlib/libc/time/asctime_r.c
@@ -4,23 +4,28 @@
 
 #include <stdio.h>
 #include <time.h>
+#include "../machine/xtensa/pgmspace.h"
 
 char *
 _DEFUN (asctime_r, (tim_p, result),
 	_CONST struct tm *__restrict tim_p _AND
 	char *__restrict result)
 {
-  static _CONST char day_name[7][3] = {
+  static _CONST char day_name[7][3] PROGMEM = {
 	"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
   };
-  static _CONST char mon_name[12][3] = {
+  static _CONST char mon_name[12][3] PROGMEM = {
 	"Jan", "Feb", "Mar", "Apr", "May", "Jun", 
 	"Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
   };
 
+  char day[3];
+  memcpy_P(day, day_name, 3);
+  char mon[3];
+  memcpy_P(mon, mon_name, 3);
+
   siprintf (result, "%.3s %.3s%3d %.2d:%.2d:%.2d %d\n",
-	    day_name[tim_p->tm_wday], 
-	    mon_name[tim_p->tm_mon],
+	    day, mon,
 	    tim_p->tm_mday, tim_p->tm_hour, tim_p->tm_min,
 	    tim_p->tm_sec, 1900 + tim_p->tm_year);
   return result;

--- a/newlib/libc/time/mktime.c
+++ b/newlib/libc/time/mktime.c
@@ -50,17 +50,18 @@ ANSI C requires <<mktime>>.
 #include <stdlib.h>
 #include <time.h>
 #include "local.h"
+#include "../machine/xtensa/pgmspace.h"
 
 #define _SEC_IN_MINUTE 60L
 #define _SEC_IN_HOUR 3600L
 #define _SEC_IN_DAY 86400L
 
-static _CONST int DAYS_IN_MONTH[12] =
+static _CONST char DAYS_IN_MONTH[12] PROGMEM =
 {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 
-#define _DAYS_IN_MONTH(x) ((x == 1) ? days_in_feb : DAYS_IN_MONTH[x])
+#define _DAYS_IN_MONTH(x) ((x == 1) ? days_in_feb : pgm_read_byte(&DAYS_IN_MONTH[x]))
 
-static _CONST int _DAYS_BEFORE_MONTH[12] =
+static _CONST short _DAYS_BEFORE_MONTH[12] PROGMEM =
 {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334};
 
 #define _ISLEAP(y) (((y) % 4) == 0 && (((y) % 100) != 0 || (((y)+1900) % 400) == 0))
@@ -171,7 +172,7 @@ _DEFUN(mktime, (tim_p),
 
   /* compute days in year */
   days += tim_p->tm_mday - 1;
-  days += _DAYS_BEFORE_MONTH[tim_p->tm_mon];
+  days += pgm_read_word(&_DAYS_BEFORE_MONTH[tim_p->tm_mon]);
   if (tim_p->tm_mon > 1 && _DAYS_IN_YEAR (tim_p->tm_year) == 366)
     days++;
 

--- a/newlib/libc/time/strptime.c
+++ b/newlib/libc/time/strptime.c
@@ -38,10 +38,11 @@
 #include <ctype.h>
 #include <stdlib.h>
 #include "../locale/timelocal.h"
+#include "../machine/xtensa/pgmspace.h"
 
 #define _ctloc(x) (_CurrentTimeLocale->x)
 
-static _CONST int _DAYS_BEFORE_MONTH[12] =
+static _CONST short _DAYS_BEFORE_MONTH[12] PROGMEM =
 {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334};
 
 #define SET_MDAY 1
@@ -426,7 +427,7 @@ _DEFUN (strptime, (buf, format, timeptr),
 
 	if (!(ymd & SET_YDAY)) {
 	    /* ...not tm_yday, so fill it in */
-	    timeptr->tm_yday = _DAYS_BEFORE_MONTH[timeptr->tm_mon]
+	    timeptr->tm_yday = pgm_read_word(&_DAYS_BEFORE_MONTH[timeptr->tm_mon])
 		+ timeptr->tm_mday;
 	    if (!is_leap_year (timeptr->tm_year + tm_year_base)
 		|| timeptr->tm_mon < 2)
@@ -441,13 +442,13 @@ _DEFUN (strptime, (buf, format, timeptr),
 
 	if (!(ymd & SET_MON)) {
 	    /* ...not tm_mon, so fill it in, and/or... */
-	    if (timeptr->tm_yday < _DAYS_BEFORE_MONTH[1])
+	    if (timeptr->tm_yday < pgm_read_word(&_DAYS_BEFORE_MONTH[1]))
 		timeptr->tm_mon = 0;
 	    else {
 		int leap = is_leap_year (timeptr->tm_year + tm_year_base);
 		int i;
 		for (i = 2; i < 12; ++i) {
-		    if (timeptr->tm_yday < _DAYS_BEFORE_MONTH[i] + leap)
+		    if (timeptr->tm_yday < pgm_read_word(&_DAYS_BEFORE_MONTH[i]) + leap)
 			break;
 		}
 		timeptr->tm_mon = i - 1;
@@ -457,7 +458,7 @@ _DEFUN (strptime, (buf, format, timeptr),
 	if (!(ymd & SET_MDAY)) {
 	    /* ...not tm_mday, so fill it in */
 	    timeptr->tm_mday = timeptr->tm_yday
-		- _DAYS_BEFORE_MONTH[timeptr->tm_mon];
+		- pgm_read_word(&_DAYS_BEFORE_MONTH[timeptr->tm_mon]);
 	    if (!is_leap_year (timeptr->tm_year + tm_year_base)
 		|| timeptr->tm_mon < 2)
 	    {


### PR DESCRIPTION
This patch is related to https://github.com/esp8266/Arduino/issues/3740 , increasing heap RAM on the ESP8266 by moving library constants into ROM.

asctime has the months of the year and day of the week as a set of
constant strings.  Move them to progmem to save 3*(7+12) = 57 bytes.
mktime has a couple array of 12 ints, move to PMEM, save 96 bytes.
strptime has 12 ints (duplicated from mktime!), move to PMEM, save 48 bytes.