### PR TITLE
Enable native PROGMEM for format and parameters

### DIFF
--- a/newlib/libc/machine/xtensa/pgmspace.h
+++ b/newlib/libc/machine/xtensa/pgmspace.h
@@ -1,0 +1,48 @@
+#ifndef ARDUINO
+
+#ifndef __PGMSPACE__
+#define __PGMSPACE__
+
+#include <stdint.h>
+
+#define PROGMEM __attribute__((section(".irom.text")))
+
+// flash memory must be read using 32 bit aligned addresses else a processor
+// exception will be triggered
+// order within the 32 bit values are
+// --------------
+// b3, b2, b1, b0
+//     w1,     w0
+
+#define pgm_read_with_offset(addr, res) \
+  asm("extui    %0, %1, 0, 2\n"     /* Extract offset within word (in bytes) */ \
+      "sub      %1, %1, %0\n"       /* Subtract offset from addr, yielding an aligned address */ \
+      "l32i.n   %1, %1, 0x0\n"      /* Load word from aligned address */ \
+      "slli     %0, %0, 3\n"        /* Mulitiply offset by 8, yielding an offset in bits */ \
+      "ssr      %0\n"               /* Prepare to shift by offset (in bits) */ \
+      "srl      %0, %1\n"           /* Shift right; now the requested byte is the first one */ \
+      :"=r"(res), "=r"(addr) \
+      :"1"(addr) \
+      :);
+
+static inline uint8_t pgm_read_byte_inlined(const void* addr) {
+  register uint32_t res;
+  pgm_read_with_offset(addr, res);
+  return (uint8_t) res;     /* This masks the lower byte from the returned word */
+}
+
+/* Although this says "word", it's actually 16 bit, i.e. half word on Xtensa */
+static inline uint16_t pgm_read_word_inlined(const void* addr) {
+  register uint32_t res;
+  pgm_read_with_offset(addr, res);
+  return (uint16_t) res;    /* This masks the lower half-word from the returned word */
+}
+
+// Make sure, that libraries checking existence of this macro are not failing
+#define pgm_read_byte(addr) pgm_read_byte_inlined(addr)
+#define pgm_read_word(addr) pgm_read_word_inlined(addr)
+
+#endif //__PGMSPACE__
+
+#endif // ARDUINO
+

--- a/newlib/libc/stdio/nano-vfprintf_i.c
+++ b/newlib/libc/stdio/nano-vfprintf_i.c
@@ -43,6 +43,7 @@
 #include "fvwrite.h"
 #include "vfieeefp.h"
 #include "nano-vfprintf_local.h"
+#include "../machine/xtensa/pgmspace.h"
 
 /* Decode and print non-floating point data.  */
 int
@@ -104,6 +105,20 @@ _printf_common (struct _reent *data,
 error:
   return -1;
 }
+
+// Not defined in the ESP8266 Arduino
+static const char *memchr_P(const char *src, int c, size_t length)
+{
+  while (length--)
+    {
+      if (pgm_read_byte(src) == c) 
+        return (void *) src;
+      src++; 
+    }
+
+  return NULL;
+}
+
 int
 _printf_i (struct _reent *data, struct _prt_data_t *pdata, FILE *fp,
 	   int (*pfunc)(struct _reent *, FILE *, _CONST char *, size_t len),
@@ -216,7 +231,7 @@ number:
 	 string, and take prec == -1 into consideration.
 	 Use normal Newlib approach here to support case where cp is not
 	 nul-terminated.  */
-      char *p = memchr (cp, 0, pdata->prec);
+      char *p = memchr_P (cp, 0, pdata->prec);
 
       if (p != NULL)
 	pdata->prec = p - cp;


### PR DESCRIPTION
This patch is related to https://github.com/esp8266/Arduino/issues/3740 , increasing heap RAM on the ESP8266.

With this patch, the *printf_P() no longer needs to be used (and no need to new[], strcpy_P, free[] the format) so the and can be remapped into a simple *printf().

This also transparently adds in support for PMEM strings using the standard "%s" format.  Due to the way vprintf() works (calls a passed-in function to actually output the characters either to RAM, serial, file, etc.) there's no real benefit in requiring a new %S format (which I think is supposed to be wide-char string per ANSI C anyway).

The only downside is the strings are now parsed char-by-char using pgm_read_byte instead of via direct pointer access.  For programs which only do printfs() this may slow things down a bit (but not yet measured, sorry, as it's not noticeable in anything I'm doing).

````
Serial.printf(test='%s'\n", "testing1");
Serial.printf(PSTR("test='%s'\n"), "testing2");
Serial.printf("test='%s'\n", PSTR("testing3"));
Serial.printf(PSTR("test='%s'\n"), PSTR("testing4"));
....
generates
....
test='testing1'
test='testing2'
test='testing3'
test='testing4'
````

The format and any %s parameters can now be read directly from PROGMEM.
This will have some performance impact in *printf-heavy applications as
all parameters (RAM and ROM) are now processed through pgm_read_byte().