### PR TITLE
Support and optimize PROGMEM accesses in libc

### DIFF
--- a/newlib/libc/ctype/ctype_.c
+++ b/newlib/libc/ctype/ctype_.c
@@ -137,7 +137,7 @@ _CONST char _ctype_[1 + 256] = {
 
 #else	/* !defined(ALLOW_NEGATIVE_CTYPE_INDEX) */
 
-_CONST char _ctype_[1 + 256] = {
+_CONST char _ctype_[1 + 256] PROGMEM = {
 	0,
 	_CTYPE_DATA_0_127,
 	_CTYPE_DATA_128_255

--- a/newlib/libc/ctype/isalnum.c
+++ b/newlib/libc/ctype/isalnum.c
@@ -41,6 +41,6 @@ No OS subroutines are required.
 int
 _DEFUN(isalnum,(c),int c)
 {
-	return(__ctype_ptr__[c+1] & (_U|_L|_N));
+	return(pgm_read_byte(&__ctype_ptr__[c+1]) & (_U|_L|_N));
 }
 

--- a/newlib/libc/ctype/isalpha.c
+++ b/newlib/libc/ctype/isalpha.c
@@ -39,6 +39,6 @@ No supporting OS subroutines are required.
 int
 _DEFUN(isalpha,(c),int c)
 {
-	return(__ctype_ptr__[c+1] & (_U|_L));
+	return(pgm_read_byte(&__ctype_ptr__[c+1]) & (_U|_L));
 }
 

--- a/newlib/libc/ctype/isblank.c
+++ b/newlib/libc/ctype/isblank.c
@@ -38,5 +38,5 @@ No supporting OS subroutines are required.
 int
 _DEFUN(isblank,(c),int c)
 {
-	return ((__ctype_ptr__[c+1] & _B) || (c == '\t'));
+	return ((pgm_read_byte(&__ctype_ptr__[c+1]) & _B) || (c == '\t'));
 }

--- a/newlib/libc/ctype/iscntrl.c
+++ b/newlib/libc/ctype/iscntrl.c
@@ -42,7 +42,7 @@ No supporting OS subroutines are required.
 int
 _DEFUN(iscntrl,(c),int c)
 {
-	return(__ctype_ptr__[c+1] & _C);
+	return(pgm_read_byte(&__ctype_ptr__[c+1]) & _C);
 }
 
 

--- a/newlib/libc/ctype/isdigit.c
+++ b/newlib/libc/ctype/isdigit.c
@@ -39,5 +39,5 @@ No supporting OS subroutines are required.
 int
 _DEFUN(isdigit,(c),int c)
 {
-	return(__ctype_ptr__[c+1] & _N);
+	return(pgm_read_byte(&__ctype_ptr__[c+1]) & _N);
 }

--- a/newlib/libc/ctype/islower.c
+++ b/newlib/libc/ctype/islower.c
@@ -39,6 +39,6 @@ No supporting OS subroutines are required.
 int
 _DEFUN(islower,(c),int c)
 {
-	return ((__ctype_ptr__[c+1] & (_U|_L)) == _L);
+	return ((pgm_read_byte(&__ctype_ptr__[c+1]) & (_U|_L)) == _L);
 }
 

--- a/newlib/libc/ctype/isprint.c
+++ b/newlib/libc/ctype/isprint.c
@@ -48,7 +48,7 @@ No supporting OS subroutines are required.
 int
 _DEFUN(isgraph,(c),int c)
 {
-	return(__ctype_ptr__[c+1] & (_P|_U|_L|_N));
+	return(pgm_read_byte(&__ctype_ptr__[c+1]) & (_P|_U|_L|_N));
 }
 
 
@@ -56,6 +56,6 @@ _DEFUN(isgraph,(c),int c)
 int
 _DEFUN(isprint,(c),int c)
 {
-	return(__ctype_ptr__[c+1] & (_P|_U|_L|_N|_B));
+	return(pgm_read_byte(&__ctype_ptr__[c+1]) & (_P|_U|_L|_N|_B));
 }
 

--- a/newlib/libc/ctype/ispunct.c
+++ b/newlib/libc/ctype/ispunct.c
@@ -41,6 +41,6 @@ No supporting OS subroutines are required.
 int
 _DEFUN(ispunct,(c),int c)
 {
-	return(__ctype_ptr__[c+1] & _P);
+	return(pgm_read_byte(&__ctype_ptr__[c+1]) & _P);
 }
 

--- a/newlib/libc/ctype/isspace.c
+++ b/newlib/libc/ctype/isspace.c
@@ -39,6 +39,6 @@ No supporting OS subroutines are required.
 int
 _DEFUN(isspace,(c),int c)
 {
-	return(__ctype_ptr__[c+1] & _S);
+	return(pgm_read_byte(&__ctype_ptr__[c+1]) & _S);
 }
 

--- a/newlib/libc/ctype/isupper.c
+++ b/newlib/libc/ctype/isupper.c
@@ -38,6 +38,6 @@ No supporting OS subroutines are required.
 int
 _DEFUN(isupper,(c),int c)
 {
-	return ((__ctype_ptr__[c+1] & (_U|_L)) == _U);
+	return ((pgm_read_byte(&__ctype_ptr__[c+1]) & (_U|_L)) == _U);
 }
 

--- a/newlib/libc/ctype/isxdigit.c
+++ b/newlib/libc/ctype/isxdigit.c
@@ -40,6 +40,6 @@ No supporting OS subroutines are required.
 int
 _DEFUN(isxdigit,(c),int c)
 {
-	return(__ctype_ptr__[c+1] & ((_X)|(_N)));
+	return(pgm_read_byte(&__ctype_ptr__[c+1]) & ((_X)|(_N)));
 }
 

--- a/newlib/libc/include/assert.h
+++ b/newlib/libc/include/assert.h
@@ -7,14 +7,15 @@ extern "C" {
 #endif
 
 #include "_ansi.h"
+#include <sys/pgmspace.h>
 
 #undef assert
 
 #ifdef NDEBUG           /* required by ANSI standard */
 # define assert(__e) ((void)0)
 #else
-# define assert(__e) ((__e) ? (void)0 : __assert_func (__FILE__, __LINE__, \
-						       __ASSERT_FUNC, #__e))
+# define assert(__e) ((__e) ? (void)0 : __assert_func (PSTR(__FILE__), __LINE__, \
+						       __ASSERT_FUNC, PSTR(#__e)))
 
 # ifndef __ASSERT_FUNC
   /* Use g++'s demangled names in C++.  */

--- a/newlib/libc/include/ctype.h
+++ b/newlib/libc/include/ctype.h
@@ -2,6 +2,7 @@
 #define _CTYPE_H_
 
 #include "_ansi.h"
+#include <sys/ctype.h>
 
 _BEGIN_STD_C
 
@@ -54,7 +55,11 @@ extern	__IMPORT char	*__ctype_ptr__;
    Meanwhile, the real index to __ctype_ptr__+1 must be cast to int,
    since isalpha(0x100000001LL) must equal isalpha(1), rather than being
    an out-of-bounds reference on a 64-bit machine.  */
-#define __ctype_lookup(__c) ((__ctype_ptr__+sizeof(""[__c]))[(int)(__c)])
+#ifdef pgm_read_byte
+  #define __ctype_lookup(__c) pgm_read_byte(&(__ctype_ptr__+sizeof(""[__c]))[(int)(__c)])
+#else
+  #define __ctype_lookup(__c) ((__ctype_ptr__+sizeof(""[__c]))[(int)(__c)])
+#endif
 
 #define	isalpha(__c)	(__ctype_lookup(__c)&(_U|_L))
 #define	isupper(__c)	((__ctype_lookup(__c)&(_U|_L))==_U)

--- a/newlib/libc/include/sys/ctype.h
+++ b/newlib/libc/include/sys/ctype.h
@@ -1,0 +1,4 @@
+/* This is a dummy <sys/ctype.h> used as a placeholder for
+   systems that need to have a special header file.  */
+
+#include <sys/pgmspace.h>

--- a/newlib/libc/include/sys/pgmspace.h
+++ b/newlib/libc/include/sys/pgmspace.h
@@ -1,0 +1,54 @@
+/* PGMSPACE.H - Accessor utilities/types for accessing PROGMEM data */
+
+#ifndef _PGMSPACE_H_
+#define _PGMSPACE_H_
+
+// These are no-ops in anything but the ESP8266, where they are defined in
+// a custom sys/pgmspace.h header
+
+#ifndef ICACHE_RODATA_ATTR
+#define ICACHE_RODATA_ATTR
+#endif
+
+#ifndef PROGMEM
+#define PROGMEM
+#endif
+
+#ifndef PGM_P
+#define PGM_P
+#endif
+
+#ifndef PGM_VOID_P
+#define PGM_VOID_P
+#endif
+
+#ifndef PSTR
+#define PSTR
+#endif
+
+#ifdef __cplusplus
+    #define pgm_read_byte(addr)             (*reinterpret_cast<const uint8_t*)(addr)>
+    #define pgm_read_word(addr)             (*reinterpret_cast<const uint16_t*)(addr)>
+    #define pgm_read_dword(addr)            (*reinterpret_cast<const uint32_t*)(addr)>
+    #define pgm_read_float(addr)            (*reinterpret_cast<const float)(addr)>
+    #define pgm_read_ptr(addr)              (*reinterpret_cast<const void const *)(addr)>
+#else
+    #define pgm_read_byte(addr)             (*(const uint8_t*)(addr))
+    #define pgm_read_word(addr)             (*(const uint16_t*)(addr))
+    #define pgm_read_dword(addr)            (*(const uint32_t*)(addr))
+    #define pgm_read_float(addr)            (*(const float)(addr))
+    #define pgm_read_ptr(addr)              (*(const void const *)(addr))
+#endif
+
+#define pgm_read_byte_near(addr)        pgm_read_byte(addr)
+#define pgm_read_word_near(addr)        pgm_read_word(addr)
+#define pgm_read_dword_near(addr)       pgm_read_dword(addr)
+#define pgm_read_float_near(addr)       pgm_read_float(addr)
+#define pgm_read_ptr_near(addr)         pgm_read_ptr(addr)
+#define pgm_read_byte_far(addr)         pgm_read_byte(addr)
+#define pgm_read_word_far(addr)         pgm_read_word(addr)
+#define pgm_read_dword_far(addr)        pgm_read_dword(addr)
+#define pgm_read_float_far(addr)        pgm_read_float(addr)
+#define pgm_read_ptr_far(addr)          pgm_read_ptr(addr)
+
+#endif

--- a/newlib/libc/include/sys/pgmspace.h
+++ b/newlib/libc/include/sys/pgmspace.h
@@ -27,11 +27,11 @@
 #endif
 
 #ifdef __cplusplus
-    #define pgm_read_byte(addr)             (*reinterpret_cast<const uint8_t*)(addr)>
-    #define pgm_read_word(addr)             (*reinterpret_cast<const uint16_t*)(addr)>
-    #define pgm_read_dword(addr)            (*reinterpret_cast<const uint32_t*)(addr)>
-    #define pgm_read_float(addr)            (*reinterpret_cast<const float)(addr)>
-    #define pgm_read_ptr(addr)              (*reinterpret_cast<const void const *)(addr)>
+    #define pgm_read_byte(addr)             (*reinterpret_cast<const uint8_t*>(addr))
+    #define pgm_read_word(addr)             (*reinterpret_cast<const uint16_t*>(addr))
+    #define pgm_read_dword(addr)            (*reinterpret_cast<const uint32_t*>(addr))
+    #define pgm_read_float(addr)            (*reinterpret_cast<const float>(addr))
+    #define pgm_read_ptr(addr)              (*reinterpret_cast<const void const *>(addr))
 #else
     #define pgm_read_byte(addr)             (*(const uint8_t*)(addr))
     #define pgm_read_word(addr)             (*(const uint16_t*)(addr))

--- a/newlib/libc/machine/xtensa/Makefile.am
+++ b/newlib/libc/machine/xtensa/Makefile.am
@@ -8,7 +8,7 @@ AM_CCASFLAGS = $(INCLUDES)
 
 noinst_LIBRARIES = lib.a
 
-lib_a_SOURCES = setjmp.S memcpy.S memset.S strcmp.S strcpy.S strncpy.S strlen.S
+lib_a_SOURCES = setjmp.S memcpy.S memset.S strcmp.S strcpy.c fast_strcpy.S fast_strncpy.S strlen.S
 lib_a_CCASFLAGS=$(AM_CCASFLAGS)
 lib_a_CFLAGS=$(AM_CFLAGS)
 TARGETDOC = ../../tmp.texi

--- a/newlib/libc/machine/xtensa/Makefile.in
+++ b/newlib/libc/machine/xtensa/Makefile.in
@@ -54,8 +54,8 @@ lib_a_AR = $(AR) $(ARFLAGS)
 lib_a_LIBADD =
 am_lib_a_OBJECTS = lib_a-setjmp.$(OBJEXT) lib_a-memcpy.$(OBJEXT) \
 	lib_a-memset.$(OBJEXT) lib_a-strcmp.$(OBJEXT) \
-	lib_a-strcpy.$(OBJEXT) lib_a-strncpy.$(OBJEXT) \
-	lib_a-strlen.$(OBJEXT)
+	lib_a-fast_strcpy.$(OBJEXT) lib_a-fast_strncpy.$(OBJEXT) \
+	lib_a-strlen.$(OBJEXT) lib_a-strcpy.$(OBJEXT)
 lib_a_OBJECTS = $(am_lib_a_OBJECTS)
 DEFAULT_INCLUDES = -I.@am__isrc@
 depcomp =
@@ -175,7 +175,7 @@ AUTOMAKE_OPTIONS = cygnus
 INCLUDES = $(NEWLIB_CFLAGS) $(CROSS_CFLAGS) $(TARGET_CFLAGS)
 AM_CCASFLAGS = $(INCLUDES)
 noinst_LIBRARIES = lib.a
-lib_a_SOURCES = setjmp.S memcpy.S memset.S strcmp.S strcpy.S strncpy.S strlen.S
+lib_a_SOURCES = setjmp.S memcpy.S memset.S strcmp.S fast_strcpy.S fast_strncpy.S strcpy.c strlen.S
 lib_a_CCASFLAGS = $(AM_CCASFLAGS)
 lib_a_CFLAGS = $(AM_CFLAGS)
 TARGETDOC = ../../tmp.texi
@@ -233,6 +233,12 @@ mostlyclean-compile:
 distclean-compile:
 	-rm -f *.tab.c
 
+.c.o:
+	$(COMPILE) -c $<
+
+.c.obj:
+	$(COMPILE) -c `$(CYGPATH_W) '$<'`
+
 .S.o:
 	$(CPPASCOMPILE) -c -o $@ $<
 
@@ -263,23 +269,29 @@ lib_a-strcmp.o: strcmp.S
 lib_a-strcmp.obj: strcmp.S
 	$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-strcmp.obj `if test -f 'strcmp.S'; then $(CYGPATH_W) 'strcmp.S'; else $(CYGPATH_W) '$(srcdir)/strcmp.S'; fi`
 
-lib_a-strcpy.o: strcpy.S
-	$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-strcpy.o `test -f 'strcpy.S' || echo '$(srcdir)/'`strcpy.S
+lib_a-fast_strcpy.o: fast_strcpy.S
+	$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-fast_strcpy.o `test -f 'fast_strcpy.S' || echo '$(srcdir)/'`fast_strcpy.S
 
-lib_a-strcpy.obj: strcpy.S
-	$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-strcpy.obj `if test -f 'strcpy.S'; then $(CYGPATH_W) 'strcpy.S'; else $(CYGPATH_W) '$(srcdir)/strcpy.S'; fi`
+lib_a-fast_strcpy.obj: fast_strcpy.S
+	$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-fast_strcpy.obj `if test -f 'fast_strcpy.S'; then $(CYGPATH_W) 'fast_strcpy.S'; else $(CYGPATH_W) '$(srcdir)/fast_strcpy.S'; fi`
 
-lib_a-strncpy.o: strncpy.S
-	$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-strncpy.o `test -f 'strncpy.S' || echo '$(srcdir)/'`strncpy.S
+lib_a-fast_strncpy.o: fast_strncpy.S
+	$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-fast_strncpy.o `test -f 'fast_strncpy.S' || echo '$(srcdir)/'`fast_strncpy.S
 
-lib_a-strncpy.obj: strncpy.S
-	$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-strncpy.obj `if test -f 'strncpy.S'; then $(CYGPATH_W) 'strncpy.S'; else $(CYGPATH_W) '$(srcdir)/strncpy.S'; fi`
+lib_a-fast_strncpy.obj: fast_strncpy.S
+	$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-fast_strncpy.obj `if test -f 'fast_strncpy.S'; then $(CYGPATH_W) 'fast_strncpy.S'; else $(CYGPATH_W) '$(srcdir)/fast_strncpy.S'; fi`
 
 lib_a-strlen.o: strlen.S
 	$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-strlen.o `test -f 'strlen.S' || echo '$(srcdir)/'`strlen.S
 
 lib_a-strlen.obj: strlen.S
 	$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-strlen.obj `if test -f 'strlen.S'; then $(CYGPATH_W) 'strlen.S'; else $(CYGPATH_W) '$(srcdir)/strlen.S'; fi`
+
+lib_a-strcpy.o : strcpy.c
+	$(COMPILE) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-strcpy.o `test -f 'strcpy.c' || echo '$(srcdir)/'`strcpy.c
+
+lib_a-strcpy.obj: strcpy.c
+	$(COMPILE) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-strcpy.obj `if test -f 'strcpy.c'; then $(CYGPATH_W) 'strcpy.c'; else $(CYGPATH_W) '$(srcdir)/strcpy.c'; fi`
 
 ID: $(HEADERS) $(SOURCES) $(LISP) $(TAGS_FILES)
 	list='$(SOURCES) $(HEADERS) $(LISP) $(TAGS_FILES)'; \

--- a/newlib/libc/machine/xtensa/fast_strcpy.S
+++ b/newlib/libc/machine/xtensa/fast_strcpy.S
@@ -27,9 +27,9 @@
 	.begin schedule
 	.align	4
 	.literal_position
-	.global	strcpy
-	.type	strcpy, @function
-strcpy:
+	.global	__fast_strcpy
+	.type	__fast_strcpy, @function
+__fast_strcpy:
 	leaf_entry sp, 16
 	/* a2 = dst, a3 = src */
 
@@ -232,4 +232,4 @@ strcpy:
 #endif /* 0 */
 	.end schedule
 
-	.size	strcpy, . - strcpy
+	.size	__fast_strcpy, . - __fast_strcpy

--- a/newlib/libc/machine/xtensa/fast_strncpy.S
+++ b/newlib/libc/machine/xtensa/fast_strncpy.S
@@ -60,9 +60,9 @@ __strncpy_aux:
 
 
 	.align	4
-	.global	strncpy
-	.type	strncpy, @function
-strncpy:
+	.global	__fast_strncpy
+	.type	__fast_strncpy, @function
+__fast_strncpy:
 	leaf_entry sp, 16
 	/* a2 = dst, a3 = src */
 
@@ -255,4 +255,4 @@ strncpy:
 3:	leaf_return
 .end schedule
 
-	.size	strncpy, . - strncpy
+	.size	__fast_strncpy, . - __fast_strncpy

--- a/newlib/libc/machine/xtensa/strcpy.c
+++ b/newlib/libc/machine/xtensa/strcpy.c
@@ -1,0 +1,34 @@
+/* strcpy.c - Xtensa code to determine if source is PMEM or RAM and call appropriate strcpy routine.
+
+  GCC is a very smart compiler, and it will, in fact, replace printf(), and its
+  related functions with strcpy() calls in order to optimize speed.  This fails
+  horribly when printf(PSTR("xxx")) is called since the original strcpy can't
+  handle the PROGMEM source.
+
+  See http://www.ciselant.de/projects/gcc_printf/gcc_printf.html for more info.
+
+  There are two ways around this:
+  - Adding -fno-builtin-*printf, which slows down every printf() call that was
+    being optimized before.  GCC won't replace the printf() call with a strcpy()
+    call, and everything will work since we now support PROGMEM strings in
+    printf().
+  - Make strcpy smarter and fall back on the appropriate routine depending on
+    the source parameter.  Since on the ESP8266 PROGMEM starts at 0x40000000
+    this is a simple comparison.  In this case speed will be maintained.
+*/
+
+#include <string.h>
+
+extern char *__fast_strcpy(char *dest, const char *src);
+char *strcpy(char *dest, const char *src)
+{
+    if (src >= (const char *)0x40000000) return strcpy_P(dest, src);
+    else return __fast_strcpy(dest, src);
+}
+
+extern char *__fast_strncpy(char *dest, const char *src, size_t n);
+char *strncpy(char *dest, const char *src, size_t n)
+{
+    if (src >= (const char *)0x40000000) return strncpy_P(dest, src, n);
+    else return __fast_strncpy(dest, src, n);
+}

--- a/newlib/libc/stdio/findfp.c
+++ b/newlib/libc/stdio/findfp.c
@@ -27,11 +27,11 @@
 #include "local.h"
 
 #ifdef _REENT_SMALL
-const struct __sFILE_fake __sf_fake_stdin =
+const struct __sFILE_fake __sf_fake_stdin PROGMEM =
     {_NULL, 0, 0, 0, 0, {_NULL, 0}, 0, _NULL};
-const struct __sFILE_fake __sf_fake_stdout =
+const struct __sFILE_fake __sf_fake_stdout PROGMEM =
     {_NULL, 0, 0, 0, 0, {_NULL, 0}, 0, _NULL};
-const struct __sFILE_fake __sf_fake_stderr =
+const struct __sFILE_fake __sf_fake_stderr PROGMEM =
     {_NULL, 0, 0, 0, 0, {_NULL, 0}, 0, _NULL};
 #endif
 

--- a/newlib/libc/stdio/nano-vfprintf.c
+++ b/newlib/libc/stdio/nano-vfprintf.c
@@ -229,7 +229,7 @@ _DEFUN(__ssputs_r, (ptr, fp, buf, len),
   if (len < w)
     w = len;
 
-  (void)memmove ((_PTR) fp->_p, (_PTR) buf, (size_t) (w));
+  (void)memcpy_P ((_PTR) fp->_p, (_PTR) buf, (size_t) (w));
   fp->_w -= w;
   fp->_p += w;
   return 0;
@@ -321,7 +321,7 @@ _DEFUN(__ssprint_r, (ptr, fp, uio),
       if (len < w)
 	w = len;
 
-      (void)memmove ((_PTR) fp->_p, (_PTR) p, (size_t) (w));
+      (void)memcpy_P ((_PTR) fp->_p, (_PTR) p, (size_t) (w));
       fp->_w -= w;
       fp->_p += w;
       /* Pretend we copied all.  */
@@ -523,7 +523,7 @@ _DEFUN(_VFPRINTF_R, (data, fp, fmt0, ap),
   for (;;)
     {
       cp = fmt;
-      while (*fmt != '\0' && *fmt != '%')
+      while (pgm_read_byte(fmt) != '\0' && pgm_read_byte(fmt) != '%')
 	fmt += 1;
 
       if ((m = fmt - cp) != 0)
@@ -531,7 +531,7 @@ _DEFUN(_VFPRINTF_R, (data, fp, fmt0, ap),
 	  PRINT (cp, m);
 	  prt_data.ret += m;
 	}
-      if (*fmt == '\0')
+      if (pgm_read_byte(fmt) == '\0')
 	goto done;
 
       fmt++;		/* Skip over '%'.  */
@@ -551,7 +551,7 @@ _DEFUN(_VFPRINTF_R, (data, fp, fmt0, ap),
        *	-- ANSI X3J11
        */
       flag_chars = "#-0+ ";
-      for (; cp = memchr (flag_chars, *fmt, 5); fmt++)
+      for (; cp = memchr (flag_chars, pgm_read_byte(fmt), 5); fmt++)
 	prt_data.flags |= (1 << (cp - flag_chars));
 
       if (prt_data.flags & SPACESGN)
@@ -566,7 +566,7 @@ _DEFUN(_VFPRINTF_R, (data, fp, fmt0, ap),
 	prt_data.l_buf[0] = '+';
 
       /* The width.  */
-      if (*fmt == '*')
+      if (pgm_read_byte(fmt) == '*')
 	{
 	  /*
 	   * ``A negative field width argument is taken as a
@@ -584,15 +584,15 @@ _DEFUN(_VFPRINTF_R, (data, fp, fmt0, ap),
 	}
       else
         {
-	  for (; is_digit (*fmt); fmt++)
-	    prt_data.width = 10 * prt_data.width + to_digit (*fmt);
+	  for (; is_digit (pgm_read_byte(fmt)); fmt++)
+	    prt_data.width = 10 * prt_data.width + to_digit (pgm_read_byte(fmt));
 	}
 
       /* The precision.  */
-      if (*fmt == '.')
+      if (pgm_read_byte(fmt) == '.')
 	{
 	  fmt++;
-	  if (*fmt == '*')
+	  if (pgm_read_byte(fmt) == '*')
 	    {
 	      fmt++;
 	      prt_data.prec = GET_ARG (n, ap, int);
@@ -602,21 +602,21 @@ _DEFUN(_VFPRINTF_R, (data, fp, fmt0, ap),
 	  else
 	    {
 	      prt_data.prec = 0;
-	      for (; is_digit (*fmt); fmt++)
-		prt_data.prec = 10 * prt_data.prec + to_digit (*fmt);
+	      for (; is_digit (pgm_read_byte(fmt)); fmt++)
+		prt_data.prec = 10 * prt_data.prec + to_digit (pgm_read_byte(fmt));
 	    }
 	}
 
       /* The length modifiers.  */
       flag_chars = "hlL";
-      if ((cp = memchr (flag_chars, *fmt, 3)) != NULL)
+      if ((cp = memchr (flag_chars, pgm_read_byte(fmt), 3)) != NULL)
 	{
 	  prt_data.flags |= (SHORTINT << (cp - flag_chars));
 	  fmt++;
 	}
 
       /* The conversion specifiers.  */
-      prt_data.code = *fmt++;
+      prt_data.code = pgm_read_byte(fmt++);
       cp = memchr ("efgEFG", prt_data.code, 6);
 #ifdef FLOATING_POINT
       /* If cp is not NULL, we are facing FLOATING POINT NUMBER.  */

--- a/newlib/libc/stdlib/mprec.c
+++ b/newlib/libc/stdlib/mprec.c
@@ -84,6 +84,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <reent.h>
+#include <sys/pgmspace.h>
 #include "mprec.h"
 
 /* This is defined in sys/reent.h as (sizeof (size_t) << 3) now, as in NetBSD.
@@ -424,7 +425,7 @@ _DEFUN (pow5mult,
 {
   _Bigint *b1, *p5, *p51;
   int i;
-  static _CONST int p05[3] = {5, 25, 125};
+  static _CONST int p05[3] PROGMEM = {5, 25, 125};
 
   if ((i = k & 3) != 0)
     b = multadd (ptr, b, p05[i - 1], 0);
@@ -952,7 +953,7 @@ _DEFUN (ratio, (a, b), _Bigint * a _AND _Bigint * b)
 
 
 _CONST double
-  tens[] =
+  tens[] PROGMEM =
 {
   1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9,
   1e10, 1e11, 1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19,
@@ -961,16 +962,16 @@ _CONST double
 };
 
 #if !defined(_DOUBLE_IS_32BITS) && !defined(__v800)
-_CONST double bigtens[] =
+_CONST double bigtens[] PROGMEM =
 {1e16, 1e32, 1e64, 1e128, 1e256};
 
-_CONST double tinytens[] =
+_CONST double tinytens[] PROGMEM =
 {1e-16, 1e-32, 1e-64, 1e-128, 1e-256};
 #else
-_CONST double bigtens[] =
+_CONST double bigtens[] PROGMEM =
 {1e16, 1e32};
 
-_CONST double tinytens[] =
+_CONST double tinytens[] PROGMEM=
 {1e-16, 1e-32};
 #endif
 

--- a/newlib/libc/stdlib/strtod.c
+++ b/newlib/libc/stdlib/strtod.c
@@ -114,6 +114,7 @@ THIS SOFTWARE.
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/pgmspace.h>
 #include "mprec.h"
 #include "gdtoa.h"
 #include "gd_qnan.h"
@@ -130,7 +131,7 @@ THIS SOFTWARE.
 #undef tinytens
 /* The factor of 2^106 in tinytens[4] helps us avoid setting the underflow */
 /* flag unnecessarily.  It leads to a song and dance at the end of strtod. */
-static _CONST double tinytens[] = { 1e-16, 1e-32,
+static _CONST double tinytens[] PROGMEM = { 1e-16, 1e-32,
 #ifdef _DOUBLE_IS_32BITS
 				    0.0, 0.0, 0.0
 #else

--- a/newlib/libc/stdlib/strtod.c
+++ b/newlib/libc/stdlib/strtod.c
@@ -288,7 +288,7 @@ _DEFUN (_strtod_r, (ptr, s00, se),
 	if (*s == '0') {
 #ifndef NO_HEX_FP
 		{
-		static _CONST FPI fpi = { 53, 1-1023-53+1, 2046-1023-53+1, 1, SI };
+		static _CONST FPI fpi PROGMEM = { 53, 1-1023-53+1, 2046-1023-53+1, 1, SI };
 		Long exp;
 		__ULong bits[2];
 		switch(s[1]) {
@@ -416,7 +416,7 @@ _DEFUN (_strtod_r, (ptr, s00, se),
 #ifdef INFNAN_CHECK
 			/* Check for Nan and Infinity */
 			__ULong bits[2];
-			static _CONST FPI fpinan =	/* only 52 explicit bits */
+			static _CONST FPI fpinan PROGMEM =	/* only 52 explicit bits */
 				{ 52, 1-1023-53+1, 2046-1023-53+1, 1, SI };
 			if (!decpt)
 			 switch(c) {

--- a/newlib/libc/stdlib/utoa.c
+++ b/newlib/libc/stdlib/utoa.c
@@ -26,6 +26,7 @@ No supporting OS subroutine calls are required.
 */
 
 #include <stdlib.h>
+#include <sys/pgmspace.h>
 
 char *
 _DEFUN (__utoa, (value, str, base),
@@ -33,7 +34,7 @@ _DEFUN (__utoa, (value, str, base),
         char *str _AND 
         int base)
 {
-  const char digits[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+  static const char digits[] PROGMEM = "0123456789abcdefghijklmnopqrstuvwxyz";
   int i, j;
   unsigned remainder;
   char c;
@@ -50,7 +51,7 @@ _DEFUN (__utoa, (value, str, base),
   do 
     {
       remainder = value % base;
-      str[i++] = digits[remainder];
+      str[i++] = pgm_read_byte(&digits[remainder]);
       value = value / base;
     } while (value != 0);  
   str[i] = '\0'; 

--- a/newlib/libc/sys/xtensa/Makefile.am
+++ b/newlib/libc/sys/xtensa/Makefile.am
@@ -6,7 +6,7 @@ INCLUDES = $(NEWLIB_CFLAGS) $(CROSS_CFLAGS) $(TARGET_CFLAGS)
 
 noinst_LIBRARIES = lib.a
 
-lib_a_SOURCES = _atexit.c creat.c isatty.c clibrary_init.c lock.c
+lib_a_SOURCES = stdio_pgmspace.c string_pgmspace.c _atexit.c creat.c isatty.c clibrary_init.c lock.c
 
 all: crt0.o
 

--- a/newlib/libc/sys/xtensa/Makefile.in
+++ b/newlib/libc/sys/xtensa/Makefile.in
@@ -57,7 +57,8 @@ ARFLAGS = cru
 lib_a_AR = $(AR) $(ARFLAGS)
 lib_a_LIBADD =
 am_lib_a_OBJECTS = _atexit.$(OBJEXT) creat.$(OBJEXT) isatty.$(OBJEXT) \
-	clibrary_init.$(OBJEXT) lock.$(OBJEXT)
+	clibrary_init.$(OBJEXT) lock.$(OBJEXT) stdio_pgmspace.$(OBJEXT) \
+	string_pgmspace.$(OBJEXT)
 lib_a_OBJECTS = $(am_lib_a_OBJECTS)
 DEFAULT_INCLUDES = -I. -I$(srcdir)
 depcomp =
@@ -184,7 +185,7 @@ target_alias = @target_alias@
 AUTOMAKE_OPTIONS = cygnus
 INCLUDES = $(NEWLIB_CFLAGS) $(CROSS_CFLAGS) $(TARGET_CFLAGS)
 noinst_LIBRARIES = lib.a
-lib_a_SOURCES = _atexit.c creat.c isatty.c clibrary_init.c lock.c
+lib_a_SOURCES = _atexit.c creat.c isatty.c clibrary_init.c lock.c stdio_pgmspace.c string_pgmspace.c
 ACLOCAL_AMFLAGS = -I ../../..
 CONFIG_STATUS_DEPENDENCIES = $(newlib_basedir)/configure.host
 all: all-am

--- a/newlib/libc/sys/xtensa/stdio_pgmspace.c
+++ b/newlib/libc/sys/xtensa/stdio_pgmspace.c
@@ -1,0 +1,41 @@
+#include <stdio.h>
+#include <sys/stdio.h>
+
+/* The following functions are now effectively no-ops and call the normal
+   STDIO function because it's been modified to support PROGMEM automatically
+*/
+
+int printf_P(PGM_P formatP, ...) {
+    int ret;
+    va_list arglist;
+    va_start(arglist, formatP);
+    ret = vprintf(formatP, arglist);
+    va_end(arglist);
+    return ret;
+}
+
+int sprintf_P(char* str, PGM_P formatP, ...) {
+    int ret;
+    va_list arglist;
+    va_start(arglist, formatP);
+    ret = vsprintf(str, formatP, arglist);
+    va_end(arglist);
+    return ret;
+}
+
+int snprintf_P(char* str, size_t strSize, PGM_P formatP, ...) {
+    int ret;
+    va_list arglist;
+    va_start(arglist, formatP);
+    ret = vsnprintf(str, strSize, formatP, arglist);
+    va_end(arglist);
+    return ret;
+}
+
+
+int vsnprintf_P(char* str, size_t strSize, PGM_P formatP, va_list ap) {
+    int ret;
+    ret = vsnprintf(str, strSize, formatP, ap);
+    return ret;
+}
+

--- a/newlib/libc/sys/xtensa/string_pgmspace.c
+++ b/newlib/libc/sys/xtensa/string_pgmspace.c
@@ -1,0 +1,351 @@
+/*
+ string_pgmspace.c - string functions that support PROGMEM
+
+ Modified from original source by Earle F. Philhower, III
+ Original authorship:
+ Copyright (c) 2015 Michael C. Miller.  All right reserved.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+// TODO - Optimize these routines to use 32-bit accesses whenever possible
+
+#include <ctype.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdarg.h>
+#include <string.h>
+#include <sys/pgmspace.h>
+
+size_t strnlen_P(PGM_P s, size_t size)
+{
+    const char* cp;
+    const uint32_t *pmem;
+    char c = 0;
+
+    // Take care of any misaligned starting data
+    for (cp = s; 0 != ((uint32_t)cp & 0x3) && size != 0 ; cp++, size--) {
+        c = pgm_read_byte(cp);
+        if (!c) goto done;
+    }
+
+    // We didn't find the end in the initial misaligned bits
+    // Now try it 32-bits at a time while possible
+    pmem = (const uint32_t*)s;
+    while (size > 3) {
+      uint32_t w = *pmem;
+      if (0 == (w & 0xff)) {
+        cp = (const char *)pmem;
+        goto done;
+      }
+      w = w >> 8;
+      if (0 == (w & 0xff)) {
+        cp = (const char *)pmem + 1;
+        goto done;
+      }
+      w = w >> 8;
+      if (0 == (w & 0xff)) {
+        cp = (const char *)pmem + 2;
+        goto done;
+      }
+      w = w >> 8;
+      if (0 == (w & 0xff)) {
+        cp = (const char *)pmem + 3;
+        goto done;
+      }
+      pmem++;
+      size -= 4;
+    }
+
+    // Take care of any straggling bytes
+    for (cp = (const char *)pmem; 0 != ((uint32_t)cp & 0x3) && size != 0 ; cp++, size--) {
+        c = pgm_read_byte(cp);
+        if (!c) goto done;
+    }
+
+done:
+    return (size_t) (cp - s);
+}
+
+char* strstr_P(const char* haystack, PGM_P needle)
+{
+    const char* pn = (const char*)(needle);
+    if (haystack[0] == 0) {
+        if (pgm_read_byte(pn)) {
+	        return NULL;
+        }
+        return (char*) haystack;
+    }
+
+    while (*haystack) {
+        size_t i = 0;
+        while (true) {
+            char n = pgm_read_byte(pn + i);
+            if (n == 0) {
+                return (char *) haystack;
+            }
+            if (n != haystack[i]) {
+                break;
+            }
+            ++i;
+        }
+        ++haystack;
+    }
+    return NULL;
+}
+
+void* memcpy_P(void* dest, PGM_VOID_P src, size_t count)
+{
+    // Optimize for the case when dest and src start at 4-byte alignment
+    // In this case we can copy ~8x faster by simply reading and writing
+    // 32-bit values until there's less than a whole word left to write
+    if ( 0 == (((uint32_t)dest|(uint32_t)src) & 0x3) ) {
+        const uint32_t* read = (const uint32_t*)(src);
+        uint32_t* write = (uint32_t*)(dest);
+        while (count >= 4) {
+            *write++ = *read++;
+            count -= 4;
+        }
+        // Let default byte-by-byte finish the work
+        dest = (void *) write;
+        src = (PGM_VOID_P) read;
+    }
+
+    const uint8_t* read = (const uint8_t*)(src);
+    uint8_t* write = (uint8_t*)(dest);
+
+    while (count)
+    {
+        *write++ = pgm_read_byte(read++);
+        count--;
+    }
+
+    return dest;
+}
+
+int memcmp_P(const void* buf1, PGM_VOID_P buf2P, size_t size)
+{
+    int result = 0;
+    const uint8_t* read1 = (const uint8_t*)buf1;
+    const uint8_t* read2 = (const uint8_t*)buf2P;
+
+    while (size > 0) {
+        uint8_t ch2 = pgm_read_byte(read2);
+        uint8_t ch1 = *read1;
+        if (ch1 != ch2) {
+            result = (int)(ch1)-(int)(ch2);
+            break;
+        }
+
+        read1++;
+        read2++;
+        size--;
+    }
+
+    return result;
+}
+
+void* memccpy_P(void* dest, PGM_VOID_P src, int c, size_t count)
+{
+    uint8_t* read = (uint8_t*)src;
+    uint8_t* write = (uint8_t*)dest;
+    void* result = NULL;
+
+    while (count > 0) {
+        uint8_t ch = pgm_read_byte(read++);
+        *write++ = ch;
+        count--;
+        if (c == ch) {
+            return write; // the value after the found c
+        }
+    }
+
+    return result;
+}
+
+void* memmem_P(const void* buf, size_t bufSize, PGM_VOID_P findP, size_t findPSize)
+{
+    const uint8_t* read = (const uint8_t*)buf;
+    const uint8_t* find = (uint8_t*)findP;
+    uint8_t first = pgm_read_byte(find++);
+
+    findPSize--;
+
+    while (bufSize > 0) {
+        if (*read == first) {
+            size_t findSize = findPSize;
+            const uint8_t* tag = read + 1;
+            size_t tagBufSize = bufSize - 1;
+            const uint8_t* findTag = find;
+
+            while (tagBufSize > 0 && findSize > 0) {
+                uint8_t ch = pgm_read_byte(findTag++);
+                if (ch != *tag) {
+                    bufSize--;
+                    read++;
+                    break;
+                }
+                findSize--;
+                tagBufSize--;
+                tag++;
+            }
+            if (findSize == 0) {
+                return (void*)read;
+            }
+        }
+        else {
+            bufSize--;
+            read++;
+        }
+    }
+    return NULL;
+}
+
+char* strncpy_P(char* dest, PGM_P src, size_t size)
+{
+    bool size_known = (size != SIZE_IRRELEVANT);
+    const char* read = src;
+    char* write = dest;
+    char ch = '.';
+
+    // Optimize for the case when the src starts at 4-byte alignment
+    // In this case we can copy ~4x faster by simply reading and writing
+    // 32-bit values until there's less than a whole word left to write
+    if ( 0 == (((uint32_t)src) & 0x3) ) {
+        const uint32_t *lSrc = (const uint32_t*)src;
+        while (size >= 4) {
+            register uint32_t p = *(lSrc++);
+            *dest++ = p & 0xff;
+            if (p&0xff) {
+                p = p >> 8;
+                *dest++ = p & 0xff;
+                if (p&0xff) {
+                    p = p >> 8;
+                    *dest++ = p & 0xff;
+                    if (p&0xff) {
+                        p = p >> 8;
+                        *dest++ = p & 0xff;
+                    } else break;
+                } else break;
+            } else break;
+            size -= 4;
+        }
+        // Let default byte-by-byte finish the work
+        read = (const char *) lSrc;
+        ch = *(dest-1);
+    }
+
+    while (size > 0 && ch != '\0')
+    {
+        ch = pgm_read_byte(read++);
+        *write++ = ch;
+        size--;
+    }
+    if (size_known)
+    {
+        while (size > 0)
+        {
+            *write++ = 0;
+            size--;
+        }
+    }
+
+    return dest;
+}
+
+char* strncat_P(char* dest, PGM_P src, size_t size)
+{
+    char* write = dest;
+
+    while (*write != '\0')
+    {
+        write++;
+    }
+
+    const char* read = src;
+    char ch = '.';
+
+    while (size > 0 && ch != '\0')
+    {
+        ch = pgm_read_byte(read++);
+        *write++ = ch;
+
+        size--;
+    }
+
+    if (ch != '\0')
+    {
+        *write = '\0';
+    }
+
+    return dest;
+}
+
+int strncmp_P(const char* str1, PGM_P str2P, size_t size)
+{
+    int result = 0;
+
+    while (size > 0)
+    {
+        char ch1 = *str1++;
+        char ch2 = pgm_read_byte(str2P++);
+        result = ch1 - ch2;
+        if (result != 0 || ch2 == '\0')
+        {
+            break;
+        }
+
+        size--;
+    }
+
+    return result;
+}
+
+int strncasecmp_P(const char* str1, PGM_P str2P, size_t size)
+{
+    int result = 0;
+
+    while (size > 0)
+    {
+        char ch1 = tolower(*str1++);
+        char ch2 = tolower(pgm_read_byte(str2P++));
+        result = ch1 - ch2;
+        if (result != 0 || ch2 == '\0')
+        {
+            break;
+        }
+
+        size--;
+    }
+
+    return result;
+}
+
+void *memchr_P(const void *src_void, int c, size_t length)
+{
+    const unsigned char *src = (const unsigned char *) src_void;
+    unsigned char d = c;
+    while (length--)
+    {
+        if (pgm_read_byte(src) == d) {
+            return (void *) src;
+        }
+        src++;
+    }
+
+    return NULL;
+}
+

--- a/newlib/libc/sys/xtensa/sys/ctype.h
+++ b/newlib/libc/sys/xtensa/sys/ctype.h
@@ -1,0 +1,9 @@
+/* sys/ctype.h - PROGMEM ctype handlers */
+
+#ifndef _SYS_CTYPE_H_
+#define _SYS_CTYPE_H_
+
+// Will cause pgm_read_byte to be defined and be used by ctype macros
+#include <sys/pgmspace.h>
+
+#endif

--- a/newlib/libc/sys/xtensa/sys/pgmspace.h
+++ b/newlib/libc/sys/xtensa/sys/pgmspace.h
@@ -1,0 +1,102 @@
+/* PGMSPACE.H - Accessor utilities/types for accessing PROGMEM data */
+
+#ifndef _PGMSPACE_H_
+#define _PGMSPACE_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef ICACHE_RODATA_ATTR
+  #define ICACHE_RODATA_ATTR __attribute__((section(".irom.text")))
+#endif
+#ifndef PROGMEM
+  #define PROGMEM            ICACHE_RODATA_ATTR
+#endif
+#ifndef PGM_P
+  #define PGM_P              const char *
+#endif
+#ifndef PGM_VOID_P
+  #define PGM_VOID_P         const void *
+#endif
+
+// PSTR() macro modified to start on a 32-bit boundary.  This adds on average
+// 1.5 bytes/string, but in return memcpy_P and strcpy_P will work 4~8x faster
+#ifndef PSTR
+  #define PSTR(s)            (__extension__({static const char __c[] __attribute__((__aligned__(4))) PROGMEM = (s); &__c[0];}))
+#endif
+
+// Flash memory must be read using 32 bit aligned addresses else a processor
+// exception will be triggered.
+// The order within the 32 bit values are:
+// --------------
+// b3, b2, b1, b0
+//     w1,     w0
+
+#define pgm_read_with_offset(addr, res) \
+  asm("extui    %0, %1, 0, 2\n"     /* Extract offset within word (in bytes) */ \
+      "sub      %1, %1, %0\n"       /* Subtract offset from addr, yielding an aligned address */ \
+      "l32i.n   %1, %1, 0x0\n"      /* Load word from aligned address */ \
+      "slli     %0, %0, 3\n"        /* Mulitiply offset by 8, yielding an offset in bits */ \
+      "ssr      %0\n"               /* Prepare to shift by offset (in bits) */ \
+      "srl      %0, %1\n"           /* Shift right; now the requested byte is the first one */ \
+      :"=r"(res), "=r"(addr) \
+      :"1"(addr) \
+      :);
+
+static inline uint8_t pgm_read_byte_inlined(const void* addr) {
+  register uint32_t res;
+  pgm_read_with_offset(addr, res);
+  return (uint8_t) res;     /* This masks the lower byte from the returned word */
+}
+
+/* Although this says "word", it's actually 16 bit, i.e. half word on Xtensa */
+static inline uint16_t pgm_read_word_inlined(const void* addr) {
+  register uint32_t res;
+  pgm_read_with_offset(addr, res);
+  return (uint16_t) res;    /* This masks the lower half-word from the returned word */
+}
+
+#define pgm_read_byte(addr)             pgm_read_byte_inlined(addr)
+#define pgm_read_word(addr)             pgm_read_word_inlined(addr)
+#ifdef __cplusplus
+    #define pgm_read_dword(addr)            (*reinterpret_cast<const uint32_t*)(addr)>
+    #define pgm_read_float(addr)            (*reinterpret_cast<const float)(addr)>
+    #define pgm_read_ptr(addr)              (*reinterpret_cast<const void const *)(addr)>
+#else
+    #define pgm_read_dword(addr)            (*(const uint32_t*)(addr))
+    #define pgm_read_float(addr)            (*(const float)(addr))
+    #define pgm_read_ptr(addr)              (*(const void const *)(addr))
+#endif
+
+#define pgm_read_byte_near(addr)        pgm_read_byte(addr)
+#define pgm_read_word_near(addr)        pgm_read_word(addr)
+#define pgm_read_dword_near(addr)       pgm_read_dword(addr)
+#define pgm_read_float_near(addr)       pgm_read_float(addr)
+#define pgm_read_ptr_near(addr)         pgm_read_ptr(addr)
+#define pgm_read_byte_far(addr)         pgm_read_byte(addr)
+#define pgm_read_word_far(addr)         pgm_read_word(addr)
+#define pgm_read_dword_far(addr)        pgm_read_dword(addr)
+#define pgm_read_float_far(addr)        pgm_read_float(addr)
+#define pgm_read_ptr_far(addr)          pgm_read_ptr(addr)
+
+/* TODO: Are the following used anywhere?  If not, remove */
+#define _SFR_BYTE(n) (n)
+
+typedef void prog_void;
+typedef char prog_char;
+typedef unsigned char prog_uchar;
+typedef int8_t prog_int8_t;
+typedef uint8_t prog_uint8_t;
+typedef int16_t prog_int16_t;
+typedef uint16_t prog_uint16_t;
+typedef int32_t prog_int32_t;
+typedef uint32_t prog_uint32_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/newlib/libc/sys/xtensa/sys/stdio.h
+++ b/newlib/libc/sys/xtensa/sys/stdio.h
@@ -1,0 +1,50 @@
+/* sys/stdio.h - #defines for legacy PROGMEM _P functions (no longer needed) */
+
+#ifndef _SYS_STDIO_H_
+#define _SYS_STDIO_H_
+
+#include <sys/pgmspace.h>
+#include <stdarg.h>
+
+#ifndef _NEWLIB_STDIO_H
+#define _NEWLIB_STDIO_H
+
+#include <sys/lock.h>
+#include <sys/reent.h>
+
+/* Internal locking macros, used to protect stdio functions.  In the
+   general case, expand to nothing. Use __SSTR flag in FILE _flags to
+   detect if FILE is private to sprintf/sscanf class of functions; if
+   set then do nothing as lock is not initialised. */
+#if !defined(_flockfile)
+#ifndef __SINGLE_THREAD__
+#  define _flockfile(fp) (((fp)->_flags & __SSTR) ? 0 : __lock_acquire_recursive((fp)->_lock))
+#else
+#  define _flockfile(fp)	(_CAST_VOID 0)
+#endif
+#endif
+
+#if !defined(_funlockfile)
+#ifndef __SINGLE_THREAD__
+#  define _funlockfile(fp) (((fp)->_flags & __SSTR) ? 0 : __lock_release_recursive((fp)->_lock))
+#else
+#  define _funlockfile(fp)	(_CAST_VOID 0)
+#endif
+#endif
+
+#endif /* _NEWLIB_STDIO_H */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int     printf_P(PGM_P formatP, ...) __attribute__((format(printf, 1, 2)));
+int     sprintf_P(char *str, PGM_P formatP, ...) __attribute__((format(printf, 2, 3)));
+int     snprintf_P(char *str, size_t strSize, PGM_P formatP, ...) __attribute__((format(printf, 3, 4)));
+int     vsnprintf_P(char *str, size_t strSize, PGM_P formatP, va_list ap) __attribute__((format(printf, 3, 0)));
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/newlib/libc/sys/xtensa/sys/string.h
+++ b/newlib/libc/sys/xtensa/sys/string.h
@@ -1,0 +1,53 @@
+/*
+ * sys/string.h
+ *
+ * Xtensa custom PROGMEM string function definitions
+ */
+
+#ifndef _SYS_STRING_H_
+#define	_SYS_STRING_H_
+
+#include "_ansi.h"
+#include <sys/reent.h>
+#include <sys/cdefs.h>
+#include <sys/features.h>
+
+#define __need_size_t
+#define __need_NULL
+#include <stddef.h>
+
+#define SIZE_IRRELEVANT 0x7fffffff
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int 	 _EXFUN(memcmp_P,(const _PTR, const _PTR, size_t));
+_PTR	 _EXFUN(memmem_P, (const _PTR, size_t, const _PTR, size_t));
+_PTR 	 _EXFUN(memcpy_P,(_PTR __restrict, const _PTR __restrict, size_t));
+_PTR	 _EXFUN(memccpy_P,(_PTR __restrict, const _PTR __restrict, int, size_t));
+_PTR     _EXFUN(memchr_P,(const _PTR, int, size_t));
+
+char 	*_EXFUN(strncpy_P,(char *__restrict, const char *__restrict, size_t));
+#define strcpy_P(dest, src)          strncpy_P((dest), (src), SIZE_IRRELEVANT)
+
+char 	*_EXFUN(strncat_P,(char *__restrict, const char *__restrict, size_t));
+#define strcat_P(dest, src)          strncat_P((dest), (src), SIZE_IRRELEVANT)
+
+int	 _EXFUN(strncmp_P,(const char *, const char *, size_t));
+#define strcmp_P(str1, str2P)          strncmp_P((str1), (str2P), SIZE_IRRELEVANT)
+
+int	_EXFUN(strncasecmp_P,(const char *, const char *, size_t));
+#define strcasecmp_P(str1, str2P)          strncasecmp_P((str1), (str2P), SIZE_IRRELEVANT)
+
+size_t	 _EXFUN(strnlen_P,(const char *, size_t));
+#define strlen_P(strP)          strnlen_P((strP), SIZE_IRRELEVANT)
+
+char 	*_EXFUN(strstr_P,(const char *, const char *));
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* _SYS_STRING_H_ */

--- a/newlib/libc/time/asctime_r.c
+++ b/newlib/libc/time/asctime_r.c
@@ -4,16 +4,17 @@
 
 #include <stdio.h>
 #include <time.h>
+#include <sys/pgmspace.h>
 
 char *
 _DEFUN (asctime_r, (tim_p, result),
 	_CONST struct tm *__restrict tim_p _AND
 	char *__restrict result)
 {
-  static _CONST char day_name[7][3] = {
+  static _CONST char day_name[7][3] PROGMEM = {
 	"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
   };
-  static _CONST char mon_name[12][3] = {
+  static _CONST char mon_name[12][3] PROGMEM = {
 	"Jan", "Feb", "Mar", "Apr", "May", "Jun", 
 	"Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
   };

--- a/newlib/libc/time/mktime.c
+++ b/newlib/libc/time/mktime.c
@@ -49,18 +49,19 @@ ANSI C requires <<mktime>>.
 
 #include <stdlib.h>
 #include <time.h>
+#include <sys/pgmspace.h>
 #include "local.h"
 
 #define _SEC_IN_MINUTE 60L
 #define _SEC_IN_HOUR 3600L
 #define _SEC_IN_DAY 86400L
 
-static _CONST int DAYS_IN_MONTH[12] =
+static _CONST int DAYS_IN_MONTH[12] PROGMEM =
 {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 
 #define _DAYS_IN_MONTH(x) ((x == 1) ? days_in_feb : DAYS_IN_MONTH[x])
 
-static _CONST int _DAYS_BEFORE_MONTH[12] =
+static _CONST int _DAYS_BEFORE_MONTH[12] PROGMEM =
 {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334};
 
 #define _ISLEAP(y) (((y) % 4) == 0 && (((y) % 100) != 0 || (((y)+1900) % 400) == 0))

--- a/newlib/libc/time/month_lengths.c
+++ b/newlib/libc/time/month_lengths.c
@@ -7,8 +7,9 @@
  */
 
 #include "local.h"
+#include <sys/pgmspace.h>
 
-_CONST int __month_lengths[2][MONSPERYEAR] = {
+_CONST int __month_lengths[2][MONSPERYEAR] PROGMEM = {
   {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31},
   {31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}
 } ;

--- a/newlib/libc/time/strptime.c
+++ b/newlib/libc/time/strptime.c
@@ -37,11 +37,12 @@
 #include <strings.h>
 #include <ctype.h>
 #include <stdlib.h>
+#include <sys/pgmspace.h>
 #include "../locale/timelocal.h"
 
 #define _ctloc(x) (_CurrentTimeLocale->x)
 
-static _CONST int _DAYS_BEFORE_MONTH[12] =
+static _CONST int _DAYS_BEFORE_MONTH[12] PROGMEM =
 {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334};
 
 #define SET_MDAY 1


### PR DESCRIPTION
This is the wrap-up of PR #1, #2, #3 , and #4 plus the requested movement of all pgmspace-type functions and macros to move into newlib.  I've taken into account the requests on those issues in this consolidated one.  It's hard to break this into smaller ones because of the interdependence of the sys/pgmspace movement.

The associated Arduino IDE changes are in https://github.com/esp8266/Arduino/pull/4160 . 
---snip---
Move all the pgmspace.(cpp/h) macros and functions from Arduino IDE
into newlib as a first-class citizen.  All the mem*_P, str*_P, and
*printf_P functions are included in this move, as well as the
PROGMEM macro and pgm_read_*.

Allow for use of PROGMEM based format and parameter strings in all
*printf functions.  No need for copying PSTR()s into RAM before printing
them out.

Add "%S" (capital-S) format that I've been told, but cannot verify,
is used in Arduino to specify a PROGMEM string parameter in printfs,
as an alias for "%s" since plain "%s" can now handle PROGMEM.

PSTR() to 4-byte alignment.  This results in an average wasted space of
1.5bytes/string (25% @0, 25%@1, 25%@2, 25%@3 == 1.5) but allows for
aligned memcpy_P and str(n)cpy_P performance to go up by 4x to 8x by
using 32-bit progmem reads instead of 4 single-byte pgm_read_byte
macros (which are many instructions in length, too).

Optimized the memcpy_P and strncpy_P functions to use 32-bit direct reads
whenver possible (source and dest alignment mediated), but there is
still room for improvement in others like *_P.

str(n)cpy now also transparently supports PROGMEM and RAM, only using
the slower PROGMEM version when the source is in PROGMEM.  This was
due to a GCC optimization:  When GCC sees a printf("xxxx") or a
printf("%s", "string") it silently optimizes out the printf and replaces
it with an appropriate strcpy.  So the changes to printf to support
PROGMEM wouldn't ever be invoked, and instead GCC silently calls strcpy
with both RAM and PSTR strings.

Finally, move several constant arrays from RODATA into PROGMEM and
update their accessors.  Among these are the ctype array, ~260 bytes,
mprec* arrays, ~300 bytes, and strings/daycounts in the time
formatting functions, ~200 bytes.