### PR TITLE
Fix several optimized corner cases

### DIFF
--- a/newlib/libc/sys/xtensa/string_pgmspace.c
+++ b/newlib/libc/sys/xtensa/string_pgmspace.c
@@ -114,23 +114,23 @@ char* strstr_P(const char* haystack, PGM_P needle)
 
 void* memcpy_P(void* dest, PGM_VOID_P src, size_t count)
 {
+    const uint8_t* read = (const uint8_t*)(src);
+    uint8_t* write = (uint8_t*)(dest);
+
     // Optimize for the case when dest and src start at 4-byte alignment
     // In this case we can copy ~8x faster by simply reading and writing
     // 32-bit values until there's less than a whole word left to write
     if ( 0 == (((uint32_t)dest|(uint32_t)src) & 0x3) ) {
-        const uint32_t* read = (const uint32_t*)(src);
-        uint32_t* write = (uint32_t*)(dest);
+        const uint32_t* readW = (const uint32_t*)(src);
+        uint32_t* writeW = (uint32_t*)(dest);
         while (count >= 4) {
-            *write++ = *read++;
+            *writeW++ = *readW++;
             count -= 4;
         }
         // Let default byte-by-byte finish the work
-        dest = (void *) write;
-        src = (PGM_VOID_P) read;
+        write = (uint8_t *) writeW;
+        read = (const uint8_t*) readW;
     }
-
-    const uint8_t* read = (const uint8_t*)(src);
-    uint8_t* write = (uint8_t*)(dest);
 
     while (count)
     {

--- a/newlib/libc/sys/xtensa/string_pgmspace.c
+++ b/newlib/libc/sys/xtensa/string_pgmspace.c
@@ -37,7 +37,7 @@ size_t strnlen_P(PGM_P s, size_t size)
     char c = 0;
 
     // Take care of any misaligned starting data
-    for (cp = s; 0 != ((uint32_t)cp & 0x3) && size != 0 ; cp++, size--) {
+    for (cp = s; 0 != ((uint32_t)cp & 0x3) && size != 0 ; cp++, size--, s++) {
         c = pgm_read_byte(cp);
         if (!c) goto done;
     }


### PR DESCRIPTION
Running debug code and some of the libc test suite some errors were
found in the strlen_P, strcpy_P, and memcpy_P functions.  This fixes them
and gives 5-10x speedup vs the code in the Arduino core for these functions.